### PR TITLE
feat: Refactor for GKE, Cloud SQL, and Spanner

### DIFF
--- a/DEPLOYMENT_GUIDE.md
+++ b/DEPLOYMENT_GUIDE.md
@@ -1,0 +1,159 @@
+# Deployment Guide: Sales Application on GKE with Cloud SQL and Spanner
+
+This guide provides comprehensive instructions for deploying the dual-database sales application to two Google Kubernetes Engine (GKE) clusters (one in the US, one in Asia), connected to both Cloud SQL for PostgreSQL and Cloud Spanner.
+
+## 1. Prerequisites
+
+Before you begin, ensure you have the following installed and configured:
+- **Google Cloud SDK (`gcloud`)**: Authenticated with your GCP account (`gcloud auth login`, `gcloud config set project [YOUR_PROJECT_ID]`).
+- **`kubectl`**: The Kubernetes command-line tool.
+- **Docker**: For building and pushing container images.
+- **A Google Cloud Platform project**: With billing enabled.
+
+## 2. Infrastructure Setup
+
+### 2.1. Create an Artifact Registry Repository
+Create a repository to store your Docker images.
+```bash
+export REGION="us-central1" # Or any region of your choice
+export REPO_NAME="sales-app-repo"
+gcloud artifacts repositories create $REPO_NAME \
+    --repository-format=docker \
+    --location=$REGION \
+    --description="Docker repository for the sales application"
+```
+
+### 2.2. Set Up Cloud SQL for PostgreSQL
+Create two Cloud SQL instances, one for each region.
+
+**For the US Cluster:**
+```bash
+export US_INSTANCE_NAME="sales-db-instance-us"
+export US_REGION="us-central1"
+export DB_USER="sales_user"
+export DB_PASSWORD="your-strong-password" # Replace with a secure password
+
+gcloud sql instances create $US_INSTANCE_NAME \
+    --database-version=POSTGRES_14 \
+    --region=$US_REGION \
+    --cpu=2 \
+    --memory=4GB
+
+gcloud sql users create $DB_USER \
+    --instance=$US_INSTANCE_NAME \
+    --password=$DB_PASSWORD
+```
+**For the Asia Cluster:**
+```bash
+export ASIA_INSTANCE_NAME="sales-db-instance-asia"
+export ASIA_REGION="asia-southeast1"
+
+gcloud sql instances create $ASIA_INSTANCE_NAME \
+    --database-version=POSTGRES_14 \
+    --region=$ASIA_REGION \
+    --cpu=2 \
+    --memory=4GB
+
+gcloud sql users create $DB_USER \
+    --instance=$ASIA_INSTANCE_NAME \
+    --password=$DB_PASSWORD
+```
+
+### 2.3. Set Up Cloud Spanner
+Create two Cloud Spanner instances, one for each region.
+
+**For the US Cluster:**
+```bash
+export US_SPANNER_INSTANCE_ID="sales-spanner-us"
+export US_SPANNER_DATABASE_ID="sales-db-us"
+gcloud spanner instances create $US_SPANNER_INSTANCE_ID --config=regional-us-central1 --description="US Spanner Instance" --nodes=1
+gcloud spanner databases create $US_SPANNER_DATABASE_ID --instance=$US_SPANNER_INSTANCE_ID --ddl-file=spanner_schema.ddl
+```
+**For the Asia Cluster:**
+```bash
+export ASIA_SPANNER_INSTANCE_ID="sales-spanner-asia"
+export ASIA_SPANNER_DATABASE_ID="sales-db-asia"
+gcloud spanner instances create $ASIA_SPANNER_INSTANCE_ID --config=regional-asia-southeast1 --description="Asia Spanner Instance" --nodes=1
+gcloud spanner databases create $ASIA_SPANNER_DATABASE_ID --instance=$ASIA_SPANNER_INSTANCE_ID --ddl-file=spanner_schema.ddl
+```
+
+### 2.4. Create GKE Clusters
+Create two GKE clusters, one in the US and one in Asia.
+```bash
+# US Cluster
+gcloud container clusters create-auto sales-cluster-us --region=us-central1
+
+# Asia Cluster
+gcloud container clusters create-auto sales-cluster-asia --region=asia-southeast1
+```
+
+## 3. Build and Push the Docker Image
+
+1.  **Configure Docker**: Authenticate Docker with Artifact Registry.
+    ```bash
+    gcloud auth configure-docker $REGION-docker.pkg.dev
+    ```
+2.  **Build the Image**:
+    ```bash
+    export PROJECT_ID=$(gcloud config get-value project)
+    export IMAGE_TAG="$REGION-docker.pkg.dev/$PROJECT_ID/$REPO_NAME/sales-app:latest"
+    docker build -t $IMAGE_TAG .
+    ```
+3.  **Push the Image**:
+    ```bash
+    docker push $IMAGE_TAG
+    ```
+
+## 4. Configure Kubernetes Manifests
+
+You must replace the placeholder values in the Kubernetes configuration files before deploying.
+
+1.  **Image Path**: In `kubernetes/base/deployment.yaml`, replace `gcr.io/your-gcp-project-id/sales-app:latest` with your image path (`$IMAGE_TAG`).
+
+2.  **Base `kustomization.yaml`**: In `kubernetes/base/kustomization.yaml`:
+    - Replace `your-gcp-project-id` with your actual GCP Project ID.
+    - Replace `your-cloudsql-db-name` with the database name (e.g., `postgres`).
+    - Replace `your-cloudsql-user` with the user you created (`sales_user`).
+    - Replace `your-cloudsql-password` in the `secretGenerator` with your actual password.
+
+3.  **US Overlay**: In `kubernetes/overlays/us/config.yaml`:
+    - Set `CLOUDSQL_INSTANCE_CONNECTION_NAME` to the connection name of your US Cloud SQL instance (find it via `gcloud sql instances describe $US_INSTANCE_NAME`).
+    - Set `SPANNER_INSTANCE_ID` to `$US_SPANNER_INSTANCE_ID`.
+
+4.  **Asia Overlay**: In `kubernetes/overlays/asia/config.yaml`:
+    - Set `CLOUDSQL_INSTANCE_CONNECTION_NAME` to the connection name of your Asia Cloud SQL instance.
+    - Set `SPANNER_INSTANCE_ID` to `$ASIA_SPANNER_INSTANCE_ID`.
+
+
+## 5. Deploy the Application
+
+### 5.1. Deploy to the US Cluster
+```bash
+# Get credentials for the US cluster
+gcloud container clusters get-credentials sales-cluster-us --region=us-central1
+
+# Apply the US overlay
+kubectl apply -k kubernetes/overlays/us
+```
+
+### 5.2. Deploy to the Asia Cluster
+```bash
+# Get credentials for the Asia cluster
+gcloud container clusters get-credentials sales-cluster-asia --region=asia-southeast1
+
+# Apply the Asia overlay
+kubectl apply -k kubernetes/overlays/asia
+```
+
+## 6. Verify the Deployment
+
+For each cluster, find the external IP address of the service and access the application in your browser.
+
+```bash
+# Wait for the service to get an external IP
+kubectl get service sales-app-service --watch
+
+# Once you see an IP, open it in your browser:
+http://[EXTERNAL_IP]
+```
+You should now be able to access the sales application running in each respective region.

--- a/app.py
+++ b/app.py
@@ -1,28 +1,54 @@
 import os
+import uuid
 import psycopg2
 from flask import Flask, render_template, request, redirect, url_for
 from dotenv import load_dotenv
+from google.cloud import spanner
+from google.api_core.exceptions import GoogleAPICallError
 
-load_dotenv() # Muat variabel dari file .env
+# Load environment variables from .env file
+load_dotenv()
 
 app = Flask(__name__)
 
-# --- Konfigurasi Koneksi Database ---
-def get_db_connection():
-    """Membuat koneksi ke database Cloud SQL."""
-    conn = psycopg2.connect(
-        host=os.environ.get("DB_HOST"),
-        database=os.environ.get("DB_NAME"),
-        user=os.environ.get("DB_USER"),
-        password=os.environ.get("DB_PASSWORD")
-    )
-    return conn
+# --- Spanner Configuration ---
+SPANNER_PROJECT_ID = os.environ.get("SPANNER_PROJECT_ID")
+SPANNER_INSTANCE_ID = os.environ.get("SPANNER_INSTANCE_ID")
+SPANNER_DATABASE_ID = os.environ.get("SPANNER_DATABASE_ID")
 
-# --- Halaman Utama (Read) ---
+# Initialize Spanner client
+try:
+    spanner_client = spanner.Client(project=SPANNER_PROJECT_ID)
+    spanner_instance = spanner_client.instance(SPANNER_INSTANCE_ID)
+    spanner_database = spanner_instance.database(SPANNER_DATABASE_ID)
+except Exception as e:
+    app.logger.error(f"Failed to initialize Spanner client: {e}")
+    spanner_client = None
+    spanner_database = None
+
+# --- Cloud SQL (PostgreSQL) Configuration ---
+def get_cloudsql_connection():
+    """Establishes a connection to the Cloud SQL for PostgreSQL database."""
+    try:
+        conn = psycopg2.connect(
+            host=os.environ.get("DB_HOST"),
+            database=os.environ.get("DB_NAME"),
+            user=os.environ.get("DB_USER"),
+            password=os.environ.get("DB_PASSWORD")
+        )
+        return conn
+    except psycopg2.OperationalError as e:
+        app.logger.error(f"Could not connect to Cloud SQL: {e}")
+        return None
+
+# --- Read Operations (from Cloud SQL) ---
 @app.route('/')
 def index():
-    """Menampilkan semua data penjualan."""
-    conn = get_db_connection()
+    """Displays all sales data from Cloud SQL."""
+    conn = get_cloudsql_connection()
+    if not conn:
+        return "Error: Database connection could not be established.", 500
+
     cur = conn.cursor()
     cur.execute("SELECT sale_id, product_name, quantity, price_per_item, quantity * price_per_item AS total_price FROM sales ORDER BY sale_date DESC;")
     sales = cur.fetchall()
@@ -30,68 +56,175 @@ def index():
     conn.close()
     return render_template('index.html', sales=sales)
 
-# --- Halaman Tambah Data (Create) ---
+# --- Create Operation (Dual Write) ---
 @app.route('/add', methods=('GET', 'POST'))
 def add():
-    """Menambah data penjualan baru."""
+    """Adds a new sale to both Cloud SQL and Cloud Spanner."""
     if request.method == 'POST':
         product_name = request.form['product_name']
-        quantity = request.form['quantity']
-        price_per_item = request.form['price_per_item']
+        quantity = int(request.form['quantity'])
+        price_per_item = float(request.form['price_per_item'])
+        sale_id = str(uuid.uuid4())
 
-        conn = get_db_connection()
-        cur = conn.cursor()
-        cur.execute("INSERT INTO sales (product_name, quantity, price_per_item) VALUES (%s, %s, %s)",
-                    (product_name, quantity, price_per_item))
-        conn.commit()
-        cur.close()
-        conn.close()
-        return redirect(url_for('index'))
+        # Dual-write transaction
+        conn_sql = get_cloudsql_connection()
+        if not conn_sql:
+            return "Error: Cloud SQL connection failed.", 500
+        cur_sql = conn_sql.cursor()
+
+        try:
+            # 1. Write to Cloud SQL
+            cur_sql.execute(
+                "INSERT INTO sales (sale_id, product_name, quantity, price_per_item) VALUES (%s, %s, %s, %s)",
+                (sale_id, product_name, quantity, price_per_item)
+            )
+
+            # 2. Write to Cloud Spanner
+            if not spanner_database:
+                raise Exception("Spanner database not configured.")
+
+            def insert_spanner(transaction):
+                transaction.execute_update(
+                    "INSERT INTO sales (sale_id, product_name, quantity, price_per_item, sale_date) "
+                    "VALUES (@sale_id, @product_name, @quantity, @price_per_item, PENDING_COMMIT_TIMESTAMP())",
+                    params={
+                        "sale_id": sale_id,
+                        "product_name": product_name,
+                        "quantity": quantity,
+                        "price_per_item": price_per_item,
+                    },
+                    param_types={
+                        "sale_id": spanner.param_types.STRING,
+                        "product_name": spanner.param_types.STRING,
+                        "quantity": spanner.param_types.INT64,
+                        "price_per_item": spanner.param_types.FLOAT64,
+                    },
+                )
+            spanner_database.run_in_transaction(insert_spanner)
+
+            # 3. Commit Cloud SQL transaction if both writes are successful
+            conn_sql.commit()
+            return redirect(url_for('index'))
+
+        except (GoogleAPICallError, psycopg2.Error, Exception) as e:
+            app.logger.error(f"Dual-write failed: {e}")
+            conn_sql.rollback()
+            return f"An error occurred: {e}", 500
+        finally:
+            cur_sql.close()
+            conn_sql.close()
 
     return render_template('add.html')
 
-# --- Halaman Edit Data (Update) ---
-@app.route('/edit/<int:sale_id>', methods=('GET', 'POST'))
+# --- Update Operation (Dual Write) ---
+@app.route('/edit/<sale_id>', methods=('GET', 'POST'))
 def edit(sale_id):
-    """Mengedit data penjualan yang sudah ada."""
-    conn = get_db_connection()
-    cur = conn.cursor()
-    cur.execute("SELECT * FROM sales WHERE sale_id = %s", (sale_id,))
-    sale = cur.fetchone()
+    """Edits an existing sale in both databases."""
+    conn_sql = get_cloudsql_connection()
+    if not conn_sql:
+        return "Error: Database connection failed.", 500
+
+    cur_sql = conn_sql.cursor()
+    cur_sql.execute("SELECT sale_id, product_name, quantity, price_per_item FROM sales WHERE sale_id = %s", (sale_id,))
+    sale = cur_sql.fetchone()
 
     if request.method == 'POST':
         product_name = request.form['product_name']
-        quantity = request.form['quantity']
-        price_per_item = request.form['price_per_item']
+        quantity = int(request.form['quantity'])
+        price_per_item = float(request.form['price_per_item'])
 
-        cur.execute("UPDATE sales SET product_name = %s, quantity = %s, price_per_item = %s WHERE sale_id = %s",
-                    (product_name, quantity, price_per_item, sale_id))
-        conn.commit()
-        cur.close()
-        conn.close()
-        return redirect(url_for('index'))
+        try:
+            # 1. Update Cloud SQL
+            cur_sql.execute(
+                "UPDATE sales SET product_name = %s, quantity = %s, price_per_item = %s WHERE sale_id = %s",
+                (product_name, quantity, price_per_item, sale_id)
+            )
+
+            # 2. Update Cloud Spanner
+            if not spanner_database:
+                raise Exception("Spanner database not configured.")
+
+            def update_spanner(transaction):
+                transaction.execute_update(
+                    "UPDATE sales SET product_name = @product_name, quantity = @quantity, price_per_item = @price_per_item "
+                    "WHERE sale_id = @sale_id",
+                    params={
+                        "sale_id": sale_id,
+                        "product_name": product_name,
+                        "quantity": quantity,
+                        "price_per_item": price_per_item,
+                    },
+                    param_types={
+                        "sale_id": spanner.param_types.STRING,
+                        "product_name": spanner.param_types.STRING,
+                        "quantity": spanner.param_types.INT64,
+                        "price_per_item": spanner.param_types.FLOAT64,
+                    },
+                )
+            spanner_database.run_in_transaction(update_spanner)
+
+            # 3. Commit Cloud SQL
+            conn_sql.commit()
+            return redirect(url_for('index'))
+
+        except (GoogleAPICallError, psycopg2.Error, Exception) as e:
+            app.logger.error(f"Dual-write update failed: {e}")
+            conn_sql.rollback()
+            return f"An error occurred during update: {e}", 500
+        finally:
+            cur_sql.close()
+            conn_sql.close()
     
-    cur.close()
-    conn.close()
+    # Close cursor and connection if it's a GET request
+    cur_sql.close()
+    conn_sql.close()
     return render_template('edit.html', sale=sale)
 
-# --- Fungsi Hapus Data (Delete) ---
-@app.route('/delete/<int:sale_id>', methods=('POST',))
+# --- Delete Operation (Dual Write) ---
+@app.route('/delete/<sale_id>', methods=('POST',))
 def delete(sale_id):
-    """Menghapus data penjualan."""
-    conn = get_db_connection()
-    cur = conn.cursor()
-    cur.execute("DELETE FROM sales WHERE sale_id = %s", (sale_id,))
-    conn.commit()
-    cur.close()
-    conn.close()
-    return redirect(url_for('index'))
+    """Deletes a sale from both databases."""
+    conn_sql = get_cloudsql_connection()
+    if not conn_sql:
+        return "Error: Database connection failed.", 500
+    cur_sql = conn_sql.cursor()
 
-# --- Halaman Laporan Penjualan (Reporting) ---
+    try:
+        # 1. Delete from Cloud SQL
+        cur_sql.execute("DELETE FROM sales WHERE sale_id = %s", (sale_id,))
+
+        # 2. Delete from Cloud Spanner
+        if not spanner_database:
+            raise Exception("Spanner database not configured.")
+
+        def delete_spanner(transaction):
+            transaction.execute_update(
+                "DELETE FROM sales WHERE sale_id = @sale_id",
+                params={"sale_id": sale_id},
+                param_types={"sale_id": spanner.param_types.STRING},
+            )
+        spanner_database.run_in_transaction(delete_spanner)
+
+        # 3. Commit Cloud SQL
+        conn_sql.commit()
+        return redirect(url_for('index'))
+
+    except (GoogleAPICallError, psycopg2.Error, Exception) as e:
+        app.logger.error(f"Dual-write delete failed: {e}")
+        conn_sql.rollback()
+        return f"An error occurred during deletion: {e}", 500
+    finally:
+        cur_sql.close()
+        conn_sql.close()
+
+# --- Reporting Page (from Cloud SQL) ---
 @app.route('/report')
 def report():
-    """Menampilkan laporan total penjualan per produk."""
-    conn = get_db_connection()
+    """Displays a sales report from Cloud SQL."""
+    conn = get_cloudsql_connection()
+    if not conn:
+        return "Error: Database connection could not be established.", 500
+
     cur = conn.cursor()
     cur.execute("""
         SELECT
@@ -108,4 +241,4 @@ def report():
     return render_template('report.html', report_data=report_data)
 
 if __name__ == '__main__':
-    app.run(host='0.0.0.0', port=8080, debug=True)
+    app.run(host='0.0.0.0', port=int(os.environ.get("PORT", 8080)), debug=False)

--- a/kubernetes/base/deployment.yaml
+++ b/kubernetes/base/deployment.yaml
@@ -1,0 +1,45 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: sales-app
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: sales
+  template:
+    metadata:
+      labels:
+        app: sales
+    spec:
+      containers:
+        - name: app
+          image: gcr.io/your-gcp-project-id/sales-app:latest # <-- Replace with your image path
+          ports:
+            - containerPort: 8080
+          envFrom:
+            - configMapRef:
+                name: app-config
+            - secretRef:
+                name: app-secrets
+          env:
+            # The app connects to the proxy on localhost
+            - name: DB_HOST
+              value: "127.0.0.1"
+            - name: DB_PORT
+              value: "5432"
+
+        - name: cloud-sql-proxy
+          image: gcr.io/cloudsql-docker/gce-proxy:1.33.9
+          command:
+            - "/cloud_sql_proxy"
+            - "-instances=$(CLOUDSQL_INSTANCE_CONNECTION_NAME)=tcp:5432"
+          securityContext:
+            runAsNonRoot: true
+          envFrom:
+            - configMapRef:
+                name: app-config
+          resources:
+            requests:
+              memory: "2Gi"
+              cpu: "1"

--- a/kubernetes/base/kustomization.yaml
+++ b/kubernetes/base/kustomization.yaml
@@ -1,0 +1,21 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - deployment.yaml
+  - service.yaml
+
+configMapGenerator:
+  - name: app-config
+    literals:
+      - GKE_REGION="default" # This will be overridden by overlays
+      - SPANNER_PROJECT_ID="your-gcp-project-id"
+      - SPANNER_INSTANCE_ID="your-spanner-instance-id"
+      - SPANNER_DATABASE_ID="your-spanner-db-id"
+      - DB_NAME="your-cloudsql-db-name"
+      - DB_USER="your-cloudsql-user"
+      - CLOUDSQL_INSTANCE_CONNECTION_NAME="your-gcp-project-id:your-region:your-instance-id"
+
+secretGenerator:
+  - name: app-secrets
+    literals:
+      - DB_PASSWORD="your-cloudsql-password"

--- a/kubernetes/base/service.yaml
+++ b/kubernetes/base/service.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: sales-app-service
+spec:
+  type: LoadBalancer
+  selector:
+    app: sales
+  ports:
+    - protocol: TCP
+      port: 80
+      targetPort: 8080

--- a/kubernetes/overlays/asia/config.yaml
+++ b/kubernetes/overlays/asia/config.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: app-config
+data:
+  GKE_REGION: "asia-southeast1"
+  CLOUDSQL_INSTANCE_CONNECTION_NAME: "your-gcp-project-id:asia-southeast1:your-instance-id-asia"
+  # You can override other values here if needed, for example, if you have a different Spanner instance for Asia
+  SPANNER_INSTANCE_ID: "your-spanner-instance-id-asia"

--- a/kubernetes/overlays/asia/kustomization.yaml
+++ b/kubernetes/overlays/asia/kustomization.yaml
@@ -1,0 +1,11 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+bases:
+  - ../../base
+
+patches:
+  - path: config.yaml
+    target:
+      kind: ConfigMap
+      name: app-config
+      version: v1

--- a/kubernetes/overlays/us/config.yaml
+++ b/kubernetes/overlays/us/config.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: app-config
+data:
+  GKE_REGION: "us-central1"
+  CLOUDSQL_INSTANCE_CONNECTION_NAME: "your-gcp-project-id:us-central1:your-instance-id-us"
+  # You can override other values here if needed, for example, if you have a different Spanner instance for the US
+  SPANNER_INSTANCE_ID: "your-spanner-instance-id-us"

--- a/kubernetes/overlays/us/kustomization.yaml
+++ b/kubernetes/overlays/us/kustomization.yaml
@@ -1,0 +1,11 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+bases:
+  - ../../base
+
+patches:
+  - path: config.yaml
+    target:
+      kind: ConfigMap
+      name: app-config
+      version: v1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
-Flask==2.2.2
-psycopg2-binary==2.9.3
-python-dotenv==0.21.0
+Flask==2.3.2
+psycopg2-binary==2.9.5
+python-dotenv==1.0.0
+google-cloud-spanner==3.26.0

--- a/spanner_schema.ddl
+++ b/spanner_schema.ddl
@@ -1,0 +1,7 @@
+CREATE TABLE sales (
+    sale_id      STRING(36) NOT NULL,
+    product_name STRING(100) NOT NULL,
+    quantity     INT64 NOT NULL,
+    price_per_item FLOAT64 NOT NULL,
+    sale_date    TIMESTAMP NOT NULL OPTIONS (allow_commit_timestamp=true)
+) PRIMARY KEY (sale_id);


### PR DESCRIPTION
Refactors the application and adds comprehensive configuration for a multi-region GKE deployment.

Key changes:
- **Dual-Database Backend**: Modified `app.py` to perform dual-writes to both Cloud SQL (PostgreSQL) and Cloud Spanner for all CUD operations. Read operations are served from Cloud SQL.
- **Dependency Update**: Added `google-cloud-spanner` to `requirements.txt`.
- **Spanner Schema**: Added `spanner_schema.ddl` for the `sales` table.
- **Kubernetes Manifests**: Created a full set of Kubernetes deployment files using Kustomize, with a base configuration and overlays for `us` and `asia` regions. The deployment includes a Cloud SQL Auth Proxy sidecar for secure database connections.
- **Deployment Guide**: Added a `DEPLOYMENT_GUIDE.md` with detailed, step-by-step instructions for setting up the cloud infrastructure and deploying the application.